### PR TITLE
move focus with tab

### DIFF
--- a/background.js
+++ b/background.js
@@ -89,7 +89,7 @@ chrome.commands.onCommand.addListener(function(command) {
       yield chrome.tabs.move.toPromise(current.id, {windowId: nextWin.id, index: -1});
 
       chrome.tabs.update(current.id, {active: true});
-      // chrome.windows.update(nextWin.id, {focused: true});
+      chrome.windows.update(nextWin.id, {focused: true});
 
     }).catch(e => console.error(e));
   }


### PR DESCRIPTION
Fixes #1, so that focus moves with the moved tab.

This was achieved by just uncommenting existing code. That was easy, but makes me a bit nervous. Was there a problem with the original code that caused it to be commented out?